### PR TITLE
Added describo containers to docker-compose to provide all-in-one testing environment

### DIFF
--- a/describo-configuration.json
+++ b/describo-configuration.json
@@ -1,0 +1,54 @@
+{
+  "ui": {
+    "port": 9000,
+    "siteName": "Arkisto Platform - Describo",
+    "logo": "http://www.researchobject.org/ro-crate/assets/img/ro-crate.svg",
+    "login": "localhost",
+    "services": {
+      "localhost": false,
+      "s3": false,
+      "owncloud": true
+    },
+    "maxSessionLifetime": "86400",
+    "maxEntitiesPerTemplate": "100"
+  },
+  "api": {
+    "port": 8080,
+    "periodicProcessInterval": 300,
+    "typeDefinitions": "https://raw.githubusercontent.com/Arkisto-Platform/arkisto-type-definitions/master/types/type-definitions.json",
+    "typeDefinitionsLookup": "https://raw.githubusercontent.com/Arkisto-Platform/arkisto-type-definitions/master/types/type-definitions-lookup.json",
+    "session": {
+      "lifetime": {
+        "hours": 5
+      }
+    },
+    "identifierURISchemes": [
+      "http",
+      "https",
+      "file",
+      "arcp"
+    ],
+    "services": {
+      "owncloud": [
+        {
+          "name": "Local Test OwnCloud",
+          "url": "http://localhost:8000",
+          "internalUrl": "http://owncloud_server:8080",
+          "clientId": "AfRGQ5ywVhNQDlfGVbntjDOn2rLPTjg0SYEVBlvuYV4UrtDmmgIvKWktIMDP5Dqq",
+          "clientSecret": "WnxAqddPtPzX3lyCYijHi3pVs1HGpoumzTYSUWqrVfL0vT7E92JSzNTQABBzCaIm",
+          "redirectUri": "http://localhost:9000/owncloud-callback",
+          "oauthAuthoriseEndpoint": "/index.php/apps/oauth2/authorize",
+          "oauthTokenEndpoint": "/index.php/apps/oauth2/api/v1/token",
+          "webdavEndpoint": "/remote.php/dav"
+        }
+      ]
+    },
+    "applications": [
+      {
+        "name": "Local Test OwnCloud",
+        "url": "http://localhost:8000",
+        "secret": "IAMSECRET"
+      }
+    ]
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3"
 
 networks:
   default:
-    external:
-      name: describo-online_default
+    name: describo-online_default
 
 volumes:
   files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3"
 
-networks:
-  default:
-    name: describo-online_default
+#networks:
+#  default:
+#    name: describo-online_default
 
 volumes:
   files:
@@ -12,6 +12,8 @@ volumes:
   backup:
     driver: local
   redis:
+    driver: local
+  database_volume:
     driver: local
 
 services:
@@ -80,3 +82,48 @@ services:
       retries: 5
     volumes:
       - redis:/data
+
+  db:
+    image: postgres:13-alpine
+    hostname: db
+    tty: true
+    environment:
+      TERM: "xterm-256color"
+      POSTGRES_DB: "describo"
+      POSTGRES_USER: "admin"
+      POSTGRES_PASSWORD: "admin"
+      PGDATA: /postgresql/data
+    volumes:
+      - database_volume:/postgresql
+
+  api:
+    image: arkisto/describo-online-api:latest
+    hostname: api
+    tty: true
+    environment:
+      NODE_ENV: production
+      TERM: "xterm-256color"
+      DB_HOST: "db"
+      DB_PORT: "5432"
+      DB_USER: "admin"
+      DB_PASSWORD: "admin"
+      DB_DATABASE: "describo"
+      ADMIN_PASSWORD: "adminpass"
+    volumes:
+      - ./describo-configuration.json:/srv/api/configuration.json
+      - ./profile.schema.json:/srv/profile.schema.json
+      - ./profiles:/srv/profiles
+      - $HOME:/home/$USER
+    ports:
+      - 8080:8080
+
+  ui:
+    image: arkisto/describo-online-ui:latest
+    hostname: ui
+    tty: true
+    environment:
+      TERM: "xterm-256color"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - 9000:9000

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,52 @@
+upstream api_socket_nodes {
+    ip_hash;
+    server api:8080;
+}
+
+server {
+    listen       9000;
+    listen  [::]:9000;
+    server_name  localhost;
+    
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+
+   location ~ ^/api/(.*) {
+        resolver 127.0.0.11 valid=30s;
+        set $api api;
+        add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_send_timeout 120;
+        proxy_read_timeout 120;
+        send_timeout 120;
+        proxy_pass   http://$api:8080/$1$is_args$args;
+    }
+
+    location /socket.io/ {
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header        Host                    $host;
+        proxy_set_header        X-Real-IP               $remote_addr;
+        proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
+        proxy_pass http://api_socket_nodes/socket.io/;
+    }
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/php/lib/Controller/DescriboApiController.php
+++ b/php/lib/Controller/DescriboApiController.php
@@ -13,7 +13,7 @@ use OCP\IURLGenerator;
 
 use OCP\IRequest;
 use OCP\AppFramework\{
-    ApiController,
+    ApiController
 };
 use OCP\IConfig;
 

--- a/profile.schema.json
+++ b/profile.schema.json
@@ -1,0 +1,87 @@
+{
+    "title": "Validate Profile",
+    "description": "Validate a describo profile",
+    "type": "object",
+    "properties": {
+        "metadata": {
+            "description": "Metadata about this profile",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "description": { "type": "string" },
+                "version": { "type": "number" }
+            },
+            "required": ["name", "description", "version"],
+            "additionalProperties": false
+        },
+        "rootDatasets": {
+            "description": "Class definitions",
+            "type": "object",
+            "patternProperties": {
+                "^[A-Z,a-z]*": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "classes": {
+            "description": "Class definitions",
+            "type": "object",
+            "patternProperties": {
+                "^[A-Z,a-z]*": {
+                    "type": "object",
+                    "properties": {
+                        "definition": {
+                            "type": "string",
+                            "enum": ["inherit", "override"]
+                        },
+                        "subClassOf": { "type": "array", "items": { "type": "string" } },
+                        "inputs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": { "type": "string" },
+                                    "name": { "type": "string" },
+                                    "label": { "type": "string" },
+                                    "multiple": { "type": "boolean" },
+                                    "required": { "type": "boolean" },
+                                    "type": {
+                                        "anyOf": [
+                                            { "type": "array", "items": { "type": "string" } },
+                                            {
+                                                "type": "string",
+                                                "enum": ["Select", "MultiSelect", "Value"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["id", "name", "help"],
+                                "additionalProperties": true
+                            }
+                        }
+                    },
+                    "required": ["definition", "subClassOf", "inputs"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "enabledClasses": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "typeDefinitions": {
+            "type": "array",
+            "items": { "type": "string" }
+        }
+    },
+    "required": ["metadata", "classes"],
+    "additionalProperties": false
+}

--- a/profiles/text-commons-collection-profile.json
+++ b/profiles/text-commons-collection-profile.json
@@ -1,0 +1,460 @@
+{
+    "metadata": {
+        "name": "TextCommons top level Collection (corpus)",
+        "description": "Describo profile for https://purl.archive.org/textcommons/profile#Collection",
+        "version": 0.1
+    },
+    "rootDatasets": {
+        "Schema": { "type": "Dataset, RepositoryCollection" }
+       
+    },
+    "classes": {
+        "Dataset": {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+                {
+                    "id": "http://schema.org/conformsTo",
+                    "name": "conformsTo",
+                    "help": "A link to the Text Commons RO-Crate profile for collections",
+                    "type": ["SelectURL"],
+                    "values" :[
+                        "https://purl.archive.org/textcommons/profile#Collection"
+                    ],
+                    "multiple": false
+                },
+              {
+                "id": "https://schema.org/name",
+                "name": "name",
+                "label": "Name",
+                "help": "The name of this collection",
+                "required": true,
+                "multiple": false,
+                "type": ["Text"]
+            },
+            {
+                "id": "http://schema.org/author",
+                "name": "author",
+                "help": "The person or organization responsible for creating this collection of data",
+                "type": ["Person", "Organization"],
+                "multiple": true
+            },
+            {
+                "id": "http://schema.org/publisher]",
+                "name": "publisher",
+                "help": "The organization responsible for releasing this collection of data",
+                "type": ["Organization"],
+                "multiple": true
+            },
+            {
+                "id": "http://schema.org/funder",
+                "name": "funder",
+                "help": "Organization(s) responsible for funding the creation or collection of this data",
+                "type": ["Organization"],
+                "multiple": true
+            },
+              {
+                "id": "http://schema.org/citation",
+                "name": "citation",
+                "help": "Associated Publications",
+                "type": ["Book", "ScholarlyArticle", "CreativeWork"],
+                "multiple": true
+            },
+            {
+              "id": "http://schema.org/description",
+              "name": "description",
+              "help": "An abstract of the collection. Include as much detail as possible about the motivation and use of the collection, including things that we do not yet have properties for",
+              "type": ["TextArea"],
+              "multiple": false
+          },
+          {
+            "id": "http://schema.org/temporalCoverage",
+            "name": "temporalCoverage",
+            "help": "The range of years of creation for items in this dataset eg 1900-1945. If there are sub collections with different coverages put this on the sub-collections not the top-level. ",
+            "type": ["Text"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/hasCollectionProtocol",
+            "name": "hasCollectionProtocol",
+            "help": "Link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection / sub-collection",
+            "type": ["CollectionProtocol"],
+            "multiple": false
+        },
+          {
+            "id": "http://schema.org/hasMember",
+            "name": "hasMember",
+            "help": "If this collection has sub-collections add them here.",
+            "type": ["RepositoryCollection"],
+            "multiple": true
+        }]},
+    
+        "RepositoryCollection": {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+                {
+                    "id": "http://schema.org/conformsTo",
+                    "name": "conformsTo",
+                    "help": "A link to the Text Commons RO-Crate profile for collections",
+                    "type": ["SelectURL"],
+                    "values" :[
+                        "https://purl.archive.org/textcommons/profile#Collection"
+                    ],
+                    "multiple": false
+                },
+              {
+                "id": "https://schema.org/name",
+                "name": "name",
+                "label": "Name",
+                "help": "The name of this collection",
+                "required": true,
+                "multiple": false,
+                "type": ["Text"]
+            },
+            {
+                "id": "http://schema.org/author",
+                "name": "author",
+                "help": "The person or organization responsible for creating this collection of data. Authors should be identified using URIs such as ORCiD or ROR",
+                "type": ["Person", "Organization"],
+                "multiple": true
+            },
+            {
+                "id": "http://schema.org/funder",
+                "name": "funder",
+                "help": "Organization(s) responsible for funding the creation or collection of this data",
+                "type": ["Organization"],
+                "multiple": true
+            },
+            {
+                "id": "http://schema.org/citation",
+                "name": "citation",
+                "help": "Associated Publications",
+                "type": ["Book", "ScholarlyArticle", "CreativeWork"],
+                "multiple": true
+            },
+            {
+              "id": "http://schema.org/description",
+              "name": "description",
+              "help": "A description of the collection",
+              "type": ["TextArea"],
+              "multiple": false
+          },
+          {
+            "id": "http://schema.org/temporalCoverage",
+            "name": "temporalCoverage",
+            "help": "The range of years of creation for items in this dataset eg 1900-1945. If there are sub collections with different coverages put this on the sub-collections not the top-level. ",
+            "type": ["Text"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/hasCollectionProtocol",
+            "name": "hasCollectionProtocol",
+            "help": "Link to a CollectionProtocol object with (at least) a summary of how resources were selected or elicited for this collection / sub-collection",
+            "type": ["CollectionProtocol"],
+            "multiple": false
+        },
+          {
+            "id": "http://schema.org/hasMember",
+            "name": "hasMember",
+            "help": "Sub Collection",
+            "type": ["RepositoryCollection"],
+            "multiple": true
+        },
+          {
+            "id": "http://schema.org/dateCreated",
+            "name": "dateCreated",
+            "help": "The (earliest) date the data in this dataset were created",
+            "type": ["Date"],
+            "multiple": false
+        }]},
+        "Book": {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+              {
+                "id": "https://schema.org/name",
+                "name": "name",
+                "label": "Name",
+                "help": "The name of this collection",
+                "required": true,
+                "multiple": false,
+                "type": ["Text"]
+            },
+            {
+                "id": "http://schema.org/author",
+                "name": "author",
+                "help": "The person or organization responsible for creating this collection of data",
+                "type": ["Person", "Organization"],
+                "multiple": true
+            },
+            {
+              "id": "http://schema.org/description",
+              "name": "description",
+              "help": "A description of the collection",
+              "type": ["TextArea"],
+              "multiple": false
+          },
+          {
+            "id": "http://schema.org/datePublished",
+            "name": "datePublished",
+            "help": "The (earliest) date the data in this dataset were created",
+            "type": ["Date"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/publisher",
+            "name": "publisher",
+            "help": "The Organization that published this work (use ROR IDs for institutions)",
+            "type": ["Organization"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/isbn",
+            "name": "isbn",
+            "help": "The ISBN for this book",
+            "type": ["Text"],
+            "multiple": false
+        }]},
+        "CreativeWork" : {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+              {
+                "id": "https://schema.org/name",
+                "name": "name",
+                "label": "Name",
+                "help": "The name of this collection",
+                "required": true,
+                "multiple": false,
+                "type": ["Text"]
+            },
+            {
+                "id": "http://schema.org/description",
+                "name": "description",
+                "help": "An abstract of the book. Include citation details.",
+                "type": ["TextArea"],
+                "multiple": false
+            },
+            {
+                "id": "http://schema.org/author",
+                "name": "author",
+                "help": "The person or organization responsible for creating this collection of data",
+                "type": ["Person", "Organization"],
+                "multiple": true
+            },
+            {
+              "id": "http://schema.org/description",
+              "name": "description",
+              "help": "A description of the collection",
+              "type": ["TextArea"],
+              "multiple": false
+          },
+          {
+            "id": "http://schema.org/datePublished",
+            "name": "datePublished",
+            "help": "The (earliest) date the data in this dataset were created",
+            "type": ["Date"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/publisher",
+            "name": "publisher",
+            "help": "The Organization that published this work (use ROR IDs for institutions",
+            "type": ["Organization"],
+            "multiple": false
+        }
+    ]
+},
+ "ScholarlyArticle" : {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+              {
+                "id": "https://schema.org/name",
+                "name": "name",
+                "label": "Name",
+                "help": "The name of this article",
+                "required": true,
+                "multiple": false,
+                "type": ["Text"]
+            },
+            {
+                "id": "http://schema.org/description",
+                "name": "description",
+                "help": "An abstract of the article, include details of how to cite it. ",
+                "type": ["TextArea"],
+                "multiple": false
+            },
+            {
+                "id": "http://schema.org/author",
+                "name": "author",
+                "help": "The person or organization responsible for creating this collection of data",
+                "type": ["Person", "Organization"],
+                "multiple": true
+            },
+            {
+              "id": "http://schema.org/description",
+              "name": "description",
+              "help": "A description of the collection",
+              "type": ["TextArea"],
+              "multiple": false
+          },
+          {
+            "id": "http://schema.org/datePublished",
+            "name": "datePublished",
+            "help": "The (earliest) date the data in this dataset were created",
+            "type": ["Date"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/publisher",
+            "name": "publisher",
+            "help": "The Organization that published this work (use ROR IDs for institution",
+            "type": ["Organization"],
+            "multiple": false
+        },
+        {
+            "id": "http://schema.org/issn",
+            "name": "issn",
+            "help": "The ISSN for this publication",
+            "type": ["Text"],
+            "multiple": false
+        }
+    ]
+},
+"CollectionProtocol" : {
+    "definition": "override",
+    "subClassOf": [],
+    "inputs": [
+      {
+        "id": "https://schema.org/name",
+        "name": "name",
+        "label": "Name",
+        "help": "The name of this artilce",
+        "required": true,
+        "multiple": false,
+        "type": ["Text"]
+    },
+    {
+        "id": "http://schema.org/description",
+        "name": "description",
+        "help": "An abstract of the article, include details of how to cite it. ",
+        "type": ["TextArea"],
+        "multiple": false
+    },
+    {
+        "id": "http://schema.org/author",
+        "name": "author",
+        "help": "The person or organization responsible for creating this collection of data",
+        "type": ["Person", "Organization"],
+        "multiple": true
+    },
+    {
+      "id": "http://schema.org/description",
+      "name": "description",
+      "help": "A summary of the collection protocol used for this collection or subcollection - eg how texts were selected, or what prompts were given to participants",
+      "type": ["TextArea"],
+      "multiple": false
+  },
+  {
+    "id": "http://purl.archive.org/textcommons/terms#CollectionProtocolType",
+    "name": "collectionProtocolType",
+    "help": "What kind of collection protocol is this",
+    "type": ["SelectObject"],
+    "values": [
+        {
+            "@id": "txc:ElicitationTask",
+            "@type": "DefinedTerm",
+            "description": "The collection protocol includes a task-based prompt to participants",
+            "inDefinedTermSet": {
+              "@id": "txc:CollectionProtocolTypeTerms"
+            },
+            "name": "ElicitationTask"
+          },{
+            "@id": "txc:TextSelectionCriteria",
+            "@type": "DefinedTerm",
+            "description": "A description of the criteria used to select texts in a collection",
+            "inDefinedTermSet": {
+              "@id": "txc:CollectionProtocolTypeTerms"
+            },
+            "name": "TextSelectionCriteria"
+          }
+
+     ], 
+    "multiple": false
+},
+  {
+    "id": "http://schema.org/datePublished",
+    "name": "datePublished",
+    "help": "The (earliest) date the data in this dataset were created",
+    "type": ["Date"],
+    "multiple": false
+}
+]
+},
+"Person": {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+                {
+                    "id": "https://schema.org/name",
+                    "name": "name",
+                    "label": "name",
+                    "help": "The name the person",
+                    "required": true,
+                    "multiple": false,
+                    "type": ["Text"]
+                },
+                {
+                    "id": "http://schema.org/description",
+                    "name": "description",
+                    "help": "Add any additional info not covered by other properties here.",
+                    "type": ["TextArea"],
+                    "multiple": false
+                },
+                {
+                    "id": "https://schema.org/affiliation",
+                    "name": "affiliation",
+                    "label": "affiliation",
+                    "help": "The name the person",
+                    "required": false,
+                    "multiple": true,
+                    "type": ["Organization"]
+                }
+            ]
+        },
+"Organization": {
+            "definition": "override",
+            "subClassOf": [],
+            "inputs": [
+                {
+                    "id": "https://schema.org/name",
+                    "name": "name",
+                    "label": "name",
+                    "help": "The name of the organization",
+                    "required": true,
+                    "multiple": false,
+                    "type": ["Text"]
+                },
+                {
+                    "id": "http://schema.org/description",
+                    "name": "description",
+                    "help": "An abstract of the collection. Include as much detail as possible about the motivation and use of the collection, including things that we do not yet have properties for",
+                    "type": ["TextArea"],
+                    "multiple": false
+                },
+                {
+                    "id": "http://schema.org/location",
+                    "name": "location",
+                    "help": "A location for the organization (eg a city for a publisher)",
+                    "type": ["Text"],
+                    "multiple": false
+                }
+            ]
+        }
+            
+        
+    },
+    "enabledClasses": ["Dataset", "Person", "Organization", "Book", "ScholarlyArticle", "RepositoryCollection", "CreativeWork", "CollectionProtocol"]
+}   


### PR DESCRIPTION
I have added the three describo containers to the docker-compose by copying all the resources from https://github.com/Arkisto-Platform/describo-local and modifying the configuration so that the describo will work with the OwnCloud containers. This will allow much easier testing of the integration because the Describo and OwnCloud instances are both pre-configured to work with eachother.